### PR TITLE
Issue #14 fixed

### DIFF
--- a/generation/poly_hgraph/mol_graph.py
+++ b/generation/poly_hgraph/mol_graph.py
@@ -13,7 +13,7 @@ class MolGraph(object):
 
     BOND_LIST = [Chem.rdchem.BondType.SINGLE, Chem.rdchem.BondType.DOUBLE, Chem.rdchem.BondType.TRIPLE, Chem.rdchem.BondType.AROMATIC] 
     MAX_POS = 20
-    FRAGMENTS = None
+    FRAGMENTS = []
 
     @staticmethod
     def load_fragments(fragments):


### PR DESCRIPTION
Simple replacement of `None` with an empty list does the job. This change has been tested by executing `python get_vocab.py --min_frequency 100 --ncpu 8 < ../data/polymers/all.txt > vocab.txt` in `generation` directory, and the bug has not appeared anymore.